### PR TITLE
Address typo in variable - then optimise it away.

### DIFF
--- a/Remediate-BreachedAccount.ps1
+++ b/Remediate-BreachedAccount.ps1
@@ -137,8 +137,7 @@ Function Disable-ForwardingRules {
 	)
     Write-Host "[$UPN] Disabling forwarding rules.."
     
-    if($ConfirmAll) { $Confrimation = $false; } else { $Comfirmation = $true; }
-    Get-InboxRule -Mailbox $upn | Where-Object {(($_.Enabled -eq $true) -and (($_.ForwardTo -ne $null) -or ($_.ForwardAsAttachmentTo -ne $null) -or ($_.RedirectTo -ne $null) -or ($_.SendTextMessageNotificationTo -ne $null)))} | Disable-InboxRule -Confirm:$Confrimation
+    Get-InboxRule -Mailbox $upn | Where-Object {(($_.Enabled -eq $true) -and (($_.ForwardTo -ne $null) -or ($_.ForwardAsAttachmentTo -ne $null) -or ($_.RedirectTo -ne $null) -or ($_.SendTextMessageNotificationTo -ne $null)))} | Disable-InboxRule -Confirm:(! $ConfirmAll)
 
 }
 


### PR DESCRIPTION
There are two different incorrect variable spellings here. I think we can do without all of them.